### PR TITLE
feat: allow "Script" dropdown control

### DIFF
--- a/javascript/config_presets.js
+++ b/javascript/config_presets.js
@@ -22,13 +22,15 @@ function config_preset_dropdown_change() {
 			gradioApp().querySelector("#txt2img_enable_hr > label > input"), // gets the <input> element next to the "Hires. fix" <span>
 			gradioApp().querySelector("#txt2img_script_container #script_list label input"), // script dropdown box in txt2img
 			gradioApp().querySelector("#img2img_script_container #script_list label input"), // script dropdown box in img2img
-		]
+		];
 
 		elementsToTrigger.forEach(el => {
-			let e = document.createEvent("HTMLEvents")
-			e.initEvent("change", true, false)
-			el.dispatchEvent(new Event("change"))
-		})
+			if (el) {
+				let e = document.createEvent("HTMLEvents");
+				e.initEvent("change", true, false);
+				el.dispatchEvent(new Event("change"));
+			}
+		});
 	}, 200) //50ms is too fast
 }
 

--- a/javascript/config_presets.js
+++ b/javascript/config_presets.js
@@ -18,14 +18,17 @@ function config_preset_dropdown_change() {
 	
 	//there is a race condition between the checkbox being checked in Python, and us firing its change event in JavaScript, so wait a bit before firing the event
 	setTimeout(function() { 
-		let hiresFixCheckbox = gradioApp().querySelector("#txt2img_enable_hr > label").firstChild //gets the <input> element next to the "Hires. fix" <span>
-		
-		let e = document.createEvent("HTMLEvents")
-		e.initEvent("change", true, false)
-		hiresFixCheckbox.dispatchEvent(e)
-		
-		//console.log("hiresFixCheckbox="+hiresFixCheckbox)
-		//console.log("e="+e)
+		let elementsToTrigger = [
+			gradioApp().querySelector("#txt2img_enable_hr > label > input"), // gets the <input> element next to the "Hires. fix" <span>
+			gradioApp().querySelector("#txt2img_script_container #script_list label input"), // script dropdown box in txt2img
+			gradioApp().querySelector("#img2img_script_container #script_list label input"), // script dropdown box in img2img
+		]
+
+		elementsToTrigger.forEach(el => {
+			let e = document.createEvent("HTMLEvents")
+			e.initEvent("change", true, false)
+			el.dispatchEvent(new Event("change"))
+		})
 	}, 200) //50ms is too fast
 }
 

--- a/scripts/config_presets.py
+++ b/scripts/config_presets.py
@@ -37,7 +37,7 @@ class Script(scripts.Script):
             "txt2img_hires_steps",
             "txt2img_denoising_strength",
             "txt2img_cfg_scale",
-
+            "script_list",
         ]
         self.img2img_component_ids = [   # mirrors the config_preset_dropdown.change(output) events and config_preset_dropdown_change()
             "img2img_sampling",
@@ -49,6 +49,7 @@ class Script(scripts.Script):
             "img2img_cfg_scale",
             "img2img_denoising_strength",
             "img2img_restore_faces",
+            "script_list",
         ]
 
         # Mapping between component labels and the actual components in ui.py


### PR DESCRIPTION
A simple change to allow controlling the "Script" dropdown.

Example configs:

```json
    "default": {
        "script_list": "None"
    },
```

```json
    "SD Upscale": {
        "script_list": "SD upscale",
        "img2img_steps": 30,
        "img2img_denoising_strength": 0.2
    },
```