### PR TITLE
fix typo `txt2txt` -> `txt2img`

### DIFF
--- a/scripts/config_presets.py
+++ b/scripts/config_presets.py
@@ -54,12 +54,12 @@ def load_txt2img_custom_tracked_component_ids() -> list[str]:
 #script_list
 
 # X/Y/Z plot (script):
-#script_txt2txt_xyz_plot_x_type
-#script_txt2txt_xyz_plot_y_type
-#script_txt2txt_xyz_plot_z_type
-#script_txt2txt_xyz_plot_x_values
-#script_txt2txt_xyz_plot_y_values
-#script_txt2txt_xyz_plot_z_values
+#script_txt2img_xyz_plot_x_type
+#script_txt2img_xyz_plot_y_type
+#script_txt2img_xyz_plot_z_type
+#script_txt2img_xyz_plot_x_values
+#script_txt2img_xyz_plot_y_values
+#script_txt2img_xyz_plot_z_values
 
 # Latent Couple (extension):
 #cd_txt2img_divisions


### PR DESCRIPTION
A typo has been corrected in the following commit of the webui repository, so I've also made the correction here to address the impact.
You can find the changes in this commit: [AUTOMATIC1111/stable-diffusion-webui #64d5fa1e](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/12653/commits/64d5fa1efd94d98ee6c97d31e85e294107b730ec).
If possible, please consider merging the changes.