### PR TITLE
fix: broken radio-button in v1.6

### DIFF
--- a/scripts/config_presets.py
+++ b/scripts/config_presets.py
@@ -913,6 +913,13 @@ class Script(scripts.Script):
                                 #print(component_name, component_value)
                                 if component_name in index_type_components and type(component_value) == int:
                                         current_components[component_name] = component_map[component_name].choices[component_value]
+
+                                        # A1111 1.6.0 changed radio buttons values into tuples.
+                                        # For example, for the "img2img_mask_mode" component it changed from:
+                                        #   ['Inpaint masked', 'Inpaint not masked']
+                                        #   to
+                                        #   [('Inpaint masked', 'Inpaint masked'), ('Inpaint not masked', 'Inpaint not masked')]
+                                        # Using a type == tuple check here will ensure compatibility with the older versions.
                                         if type(current_components[component_name]) == tuple:
                                             current_components[component_name] = current_components[component_name][0]
 

--- a/scripts/config_presets.py
+++ b/scripts/config_presets.py
@@ -913,6 +913,8 @@ class Script(scripts.Script):
                                 #print(component_name, component_value)
                                 if component_name in index_type_components and type(component_value) == int:
                                         current_components[component_name] = component_map[component_name].choices[component_value]
+                                        if type(current_components[component_name]) == tuple:
+                                            current_components[component_name] = current_components[component_name][0]
 
                             #print("Components after :", current_components)
                             


### PR DESCRIPTION
Setting of radio-button values is broken since WebUI v1.6.0.

This is because the value of radio buttons is now **list of tuples of strings**, not **list of strings** any more.

Example: radio button `img2img_mask_mode` has value of `[('Inpaint masked', 'Inpaint masked'), ('Inpaint not masked', 'Inpaint not masked')]` in v1.6, but it was `['Inpaint masked', 'Inpaint not masked']` in v1.5.
